### PR TITLE
agregué unos .write en la clase SR830 del Lock-In

### DIFF
--- a/software/python/intro comunicacion/instrumental.py
+++ b/software/python/intro comunicacion/instrumental.py
@@ -52,10 +52,10 @@ class SR830(object):
     def __init__(self,resource):
         self._lockin = visa.ResourceManager().open_resource(resource)
         print(self._lockin.query('*IDN?'))
-        self._lockin("LOCL 2") #Bloquea el uso de teclas del Lockin
+        self._lockin.write("LOCL 2") #Bloquea el uso de teclas del Lockin
         
     def __del__(self):
-        self._lockin("LOCL 0") #Desbloquea el Lockin
+        self._lockin.write("LOCL 0") #Desbloquea el Lockin
         self._lockin.close()
         
     def setModo(self, modo):


### PR DESCRIPTION
En las líneas 55 y 58 se llamaba directamente a self._lockin en vez del método write() de esta clase, lo que generaba un error.