### PR TITLE
el generador ya no se setea en 1 kHz en su init

### DIFF
--- a/software/python/intro comunicacion/instrumental.py
+++ b/software/python/intro comunicacion/instrumental.py
@@ -118,7 +118,7 @@ class AFG3021B:
         
         #Activa la salida
         self._generador.write('OUTPut1:STATe on')
-        self.setFrequency(1000)
+        # self.setFrequency(1000)
         
     def __del__(self):
         self._generador.close()


### PR DESCRIPTION
Ví que el "problema" ya fue solucionado para el osciloscopio y me pareció correcto que no se modifique la señal generada por el generador de funciones al inicializar la clase.